### PR TITLE
Added a few additional options

### DIFF
--- a/docs/bin/mp-style-parser.js
+++ b/docs/bin/mp-style-parser.js
@@ -138,6 +138,9 @@ Parser = (function() {
 
   Parser.toHTML = function(text, options) {
     var tokens;
+    if (options == null) {
+      options = {};
+    }
     this.options = {
       disableLinks: options.disableLinks,
       lightBackground: options.lightBackground

--- a/docs/bin/mp-style-parser.js
+++ b/docs/bin/mp-style-parser.js
@@ -118,8 +118,11 @@ Parser = (function() {
     return this.toHTML(text);
   }
 
-  Parser.toHTML = function(text) {
+  Parser.toHTML = function(text, options) {
     var tokens;
+    this.options = {
+      disableLinks: options.disableLinks
+    };
     return ((function() {
       var j, len, ref, results;
       ref = this.parse(text);
@@ -200,8 +203,10 @@ Parser = (function() {
               endLink();
             } else {
               endText(true);
-              nextLinkToken = new LinkToken((tok === "h" ? true : false));
-              tokens.push(nextLinkToken);
+              nextLinkToken = new LinkToken(tok === "h");
+              if (!this.options.disableLinks) {
+                tokens.push(nextLinkToken);
+              }
               isQuickLink = true;
               isPrettyLink = true;
               linkLevel = styleStack.length;
@@ -295,7 +300,7 @@ Parser = (function() {
     if (nextToken.text !== '') {
       tokens.push(nextToken);
     }
-    if (nextLinkToken != null) {
+    if ((nextLinkToken != null) && !this.options.disableLinks) {
       tokens.push(new LinkTokenEnd);
     }
     return tokens;

--- a/docs/bin/mp-style-parser.js
+++ b/docs/bin/mp-style-parser.js
@@ -52,6 +52,22 @@ Color = (function() {
     return (this.rgbToLuminance(this.hex2rgb(rgb1)) + 0.05) / (this.rgbToLuminance(this.hex2rgb(rgb2)) + 0.05);
   };
 
+  Color.invertLight = function(hex_color) {
+    var b, g, grey, r, upper;
+    r = parseInt(hex_color[0], 16) * 17;
+    g = parseInt(hex_color[1], 16) * 17;
+    b = parseInt(hex_color[2], 16) * 17;
+    grey = (r + g + b) / 3;
+    if (grey > 160) {
+      upper = 255 + 74;
+      r = Math.min(15, Math.floor((upper - r) / 17));
+      g = Math.min(15, Math.floor((upper - g) / 17));
+      b = Math.min(15, Math.floor((upper - b) / 17));
+      return r.toString(16) + g.toString(16) + b.toString(16);
+    }
+    return hex_color;
+  };
+
   return Color;
 
 })();
@@ -103,7 +119,7 @@ exports.LinkTokenEnd = LinkTokenEnd;
 
 
 },{}],5:[function(require,module,exports){
-var LinkToken, LinkTokenEnd, Parser, Style, Token;
+var Color, LinkToken, LinkTokenEnd, Parser, Style, Token;
 
 Token = require('./Token.coffee').Token;
 
@@ -113,6 +129,8 @@ LinkTokenEnd = require('./LinkTokenEnd.coffee').LinkTokenEnd;
 
 LinkToken = require('./LinkToken.coffee').LinkToken;
 
+Color = require('./Color.coffee').Color;
+
 Parser = (function() {
   function Parser(text) {
     return this.toHTML(text);
@@ -121,7 +139,8 @@ Parser = (function() {
   Parser.toHTML = function(text, options) {
     var tokens;
     this.options = {
-      disableLinks: options.disableLinks
+      disableLinks: options.disableLinks,
+      lightBackground: options.lightBackground
     };
     return ((function() {
       var j, len, ref, results;
@@ -268,6 +287,9 @@ Parser = (function() {
           addChar = true;
         }
         if (endColor) {
+          if (this.options.lightBackground) {
+            color = Color.invertLight(color);
+          }
           style = style & ~0xfff;
           style = style | Style.COLORED | (parseInt(color, 16) & 0xfff);
           endText();
@@ -313,7 +335,7 @@ Parser = (function() {
 exports.Parser = Parser;
 
 
-},{"./LinkToken.coffee":3,"./LinkTokenEnd.coffee":4,"./Style.coffee":6,"./Token.coffee":7}],6:[function(require,module,exports){
+},{"./Color.coffee":2,"./LinkToken.coffee":3,"./LinkTokenEnd.coffee":4,"./Style.coffee":6,"./Token.coffee":7}],6:[function(require,module,exports){
 var Style;
 
 Style = (function() {

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,18 +34,36 @@
 
 <p>JavaScript port of ManiaLib's PHP style parser.</p>
 
-<p>It supports : <code>$i</code>, <code>$o</code>, <code>$s</code>, <code>$w</code>, <code>$m</code>, <code>$g</code>, <code>$n</code>, <code>$&lt;</code>, <code>$&gt;</code>, <code>$l</code> (for links like <code>$l[http://maniaplanet.org]maniaplanet$l</code>) and colors (<code>$f20</code> for instance). </p>
+<p>It supports : <code>$i</code>, <code>$o</code>, <code>$s</code>, <code>$w</code>, <code>$m</code>, <code>$g</code>, <code>$n</code>, <code>$&lt;</code>, <code>$&gt;</code>, <code>$l</code> (for links like <code>$l[http://maniaplanet.com]maniaplanet$l</code>) and colors (<code>$f20</code> for instance). </p>
 
-<div>For instance : <input style="width: 100%" id="input" type="input" value="$f20Some red text,$z$o a little bold, $z$l[http://maniaplanet.org]and a link$l"/><br />will be transformed into:<br /> <div style="width: 100%; border-style:solid; padding:2px; border-width:1px;" id="result"></div></div>
+<div>
+  For instance:<br />
+  <input style="width: 100%" id="input" type="input" value="$f20Some red text,$z$o a little bold, $z$l[http://maniaplanet.com]and a link$l"/><br />
+
+  Will be transformed into:<br />
+  <div style="width: 100%; border-style:solid; padding:2px; border-width:1px;" id="result"></div>
+
+  Additional options:<br />
+  <label><input type="checkbox" id="disableLinks"> Disable links</label>
+</div>
 
 <script type="text/javascript">
+function makeOptions() {
+  return {
+    disableLinks: $('#disableLinks').prop('checked'),
+  };
+}
 function transform() {
-	$('#result').html(MPStyle.Parser.toHTML($('#input').val()));
+  var text = $('#input').val();
+  var options = makeOptions();
+  console.log(options);
+	$('#result').html(MPStyle.Parser.toHTML(text, options));
 }
 $(function() {
 	transform();
-	$('#input').change(function() { transform(); });
-	$('#input').keyup(function() { transform(); });
+  $('#disableLinks').change(transform);
+	$('#input').change(transform);
+	$('#input').keyup(transform);
 });
 
 </script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,23 +45,24 @@
 
   Additional options:<br />
   <label><input type="checkbox" id="disableLinks"> Disable links</label>
+  <label><input type="checkbox" id="lightBackground"> Optimize for light backgrounds</label>
 </div>
 
 <script type="text/javascript">
 function makeOptions() {
   return {
     disableLinks: $('#disableLinks').prop('checked'),
+    lightBackground: $('#lightBackground').prop('checked'),
   };
 }
 function transform() {
   var text = $('#input').val();
   var options = makeOptions();
-  console.log(options);
 	$('#result').html(MPStyle.Parser.toHTML(text, options));
 }
 $(function() {
 	transform();
-  $('#disableLinks').change(transform);
+  $('#disableLinks,#lightBackground').change(transform);
 	$('#input').change(transform);
 	$('#input').keyup(transform);
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -50,19 +50,19 @@
 
 <script type="text/javascript">
 function makeOptions() {
-  return {
-    disableLinks: $('#disableLinks').prop('checked'),
-    lightBackground: $('#lightBackground').prop('checked'),
-  };
+	return {
+		disableLinks: $('#disableLinks').prop('checked'),
+		lightBackground: $('#lightBackground').prop('checked'),
+	};
 }
 function transform() {
-  var text = $('#input').val();
-  var options = makeOptions();
+	var text = $('#input').val();
+	var options = makeOptions();
 	$('#result').html(MPStyle.Parser.toHTML(text, options));
 }
 $(function() {
 	transform();
-  $('#disableLinks,#lightBackground').change(transform);
+	$('#disableLinks,#lightBackground').change(transform);
 	$('#input').change(transform);
 	$('#input').keyup(transform);
 });

--- a/src/Color.coffee
+++ b/src/Color.coffee
@@ -16,4 +16,17 @@ class Color
   @contrastRatio: (rgb1, rgb2) ->
   	return (@rgbToLuminance(@hex2rgb(rgb1)) + 0.05) / (@rgbToLuminance(@hex2rgb(rgb2)) + 0.05)
 
+  @invertLight: (hex_color) ->
+    r = parseInt(hex_color[0], 16) * 17
+    g = parseInt(hex_color[1], 16) * 17
+    b = parseInt(hex_color[2], 16) * 17
+    grey = (r + g + b) / 3
+    if grey > 160
+      upper = 255 + 74
+      r = Math.min(15, Math.floor((upper - r) / 17))
+      g = Math.min(15, Math.floor((upper - g) / 17))
+      b = Math.min(15, Math.floor((upper - b) / 17))
+      return r.toString(16) + g.toString(16) + b.toString(16)
+    return hex_color
+
 exports.Color = Color

--- a/src/Parser.coffee
+++ b/src/Parser.coffee
@@ -2,6 +2,7 @@
 {Style} = require './Style.coffee'
 {LinkTokenEnd} = require './LinkTokenEnd.coffee'
 {LinkToken} = require './LinkToken.coffee'
+{Color} = require './Color.coffee'
 
 class Parser
   constructor: (text) ->
@@ -10,6 +11,7 @@ class Parser
   @toHTML: (text, options) ->
     @options =
       disableLinks: options.disableLinks
+      lightBackground: options.lightBackground
     return (tokens.toHTML() for tokens in @parse(text)).join('')
 
   @parse: (text) ->
@@ -118,6 +120,8 @@ class Parser
           addChar = true
 
         if endColor
+          if @options.lightBackground
+            color = Color.invertLight(color)
           style = style & ~0xfff;
           style = style | Style.COLORED | (parseInt(color, 16) & 0xfff)
           endText() #force end string

--- a/src/Parser.coffee
+++ b/src/Parser.coffee
@@ -7,7 +7,9 @@ class Parser
   constructor: (text) ->
     return @toHTML text
 
-  @toHTML: (text) ->
+  @toHTML: (text, options) ->
+    @options =
+      disableLinks: options.disableLinks
     return (tokens.toHTML() for tokens in @parse(text)).join('')
 
   @parse: (text) ->
@@ -65,8 +67,9 @@ class Parser
               endLink()
             else
               endText true
-              nextLinkToken = new LinkToken (if tok is "h" then true else false)
-              tokens.push nextLinkToken
+              nextLinkToken = new LinkToken(tok is "h")
+              if !@options.disableLinks
+                tokens.push nextLinkToken
               isQuickLink = true
               isPrettyLink = true
               linkLevel = styleStack.length
@@ -145,7 +148,7 @@ class Parser
     if nextToken.text isnt ''
       tokens.push nextToken
    
-    if nextLinkToken?
+    if nextLinkToken? and !@options.disableLinks
       tokens.push new LinkTokenEnd
 
     return tokens

--- a/src/Parser.coffee
+++ b/src/Parser.coffee
@@ -8,7 +8,7 @@ class Parser
   constructor: (text) ->
     return @toHTML text
 
-  @toHTML: (text, options) ->
+  @toHTML: (text, options = {}) ->
     @options =
       disableLinks: options.disableLinks
       lightBackground: options.lightBackground

--- a/test/parserTest.coffee
+++ b/test/parserTest.coffee
@@ -26,3 +26,9 @@ describe 'Parser', ->
     expect(Parser.toHTML('$f00Red')).to.equal('<span style="color: #ff0000;">Red</span>')
   it 'should handle incomplete color codes', ->
     expect(Parser.toHTML('$fRed')).to.equal('<span style="color: #ff0000;">Red</span>')
+  it 'should not add links with disableLinks', ->
+    expect(Parser.toHTML('$lmaniaplanet.com', disableLinks: true)).to.equal('maniaplanet.com')
+  it 'should not add links with specified url with disableLinks', ->
+    expect(Parser.toHTML('$l[maniaplanet.com]Maniaplanet', disableLinks: true)).to.equal('Maniaplanet')
+  it 'should be darker text with lightBackground', ->
+    expect(Parser.toHTML('$fffText', lightBackground: true)).to.equal('<span style="color: #444444;">Text</span>')


### PR DESCRIPTION
I have implemented these for Trackmania.io and Openplanet, so figured I'd contribute them back.

Here's an example of how to set options when parsing game texts:

```js
var html = MPStyle.Parser.toHTML(text, {
  disableLinks: true,
  lightBackground: true,
});
```

When passing `disableLinks: true`, it will ignore any link formatting and not add any `<a>` tags to the resulting HTML.

With `lightBackground: true`, the resulting colors in HTML will be optimized for a light background. This means that colors that would be too light for a white background will be inverted so they are darker instead. For example, in the below 2 screenshots you can see the original (black background) and the same version with the `lightBackground` option enabled:

![image](https://user-images.githubusercontent.com/136534/94862962-04cba000-043a-11eb-9aa8-c16d32416d98.png)

![image](https://user-images.githubusercontent.com/136534/94862947-fd0bfb80-0439-11eb-92b8-b54e105f375d.png)

I've also added 3 new tests for these new options.