### PR TITLE
Escape dangerous HTML characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+package-lock.json

--- a/docs/bin/mp-style-parser.js
+++ b/docs/bin/mp-style-parser.js
@@ -85,10 +85,11 @@ LinkToken = (function() {
   }
 
   LinkToken.prototype.toHTML = function() {
+    this.link = this.link.replace(/[&<>'"]+/g, encodeURIComponent);
     if (this.manialink && !/^maniaplanet:/i.test(this.link)) {
       this.link = "maniaplanet://#manialink=" + this.link;
     }
-    if (!this.manialink && !/^http:/i.test(this.link)) {
+    if (!this.manialink && !/^https?:/i.test(this.link)) {
       this.link = "http://" + this.link;
     }
     return '<a href="' + this.link + '">';
@@ -381,6 +382,9 @@ Token = (function() {
   Token.prototype.toHTML = function() {
     var color, styleStack;
     styleStack = [];
+    this.text = this.text.replace(/[&<>'"]/g, function(match) {
+      return '&#' + match.charCodeAt(0) + ';';
+    });
     if (this.style) {
       if (this.style & Style.COLORED) {
         color = parseInt(Color.rgb12to24(this.style & 0xfff), 10).toString(16);

--- a/src/LinkToken.coffee
+++ b/src/LinkToken.coffee
@@ -3,9 +3,11 @@ class LinkToken
   constructor: (@manialink = false, @link = "") ->
 
   toHTML: ->
+    @link = @link.replace /[&<>'"]+/g, encodeURIComponent
+    
     if @manialink and not /^maniaplanet:/i.test(@link)
       @link = "maniaplanet://#manialink=" + @link
-    if not @manialink and not /^http:/i.test(@link)
+    if not @manialink and not /^https?:/i.test(@link)
       @link = "http://" + @link
     return '<a href="' + @link + '">'
 	

--- a/src/Token.coffee
+++ b/src/Token.coffee
@@ -6,6 +6,8 @@ class Token
 
   toHTML: ->
     styleStack = []
+    @text = @text.replace /[&<>'"]/g, (match) -> '&#' + match.charCodeAt(0) + ';'
+    
     if @style
       if @style & Style.COLORED
         # Converting string to hex


### PR DESCRIPTION
Hopefully fixing the lib's vulnerability to xss.
As a proof of concept, the [demo](https://maniaplanet.github.io/maniaplanet-style-js-parser/) is/was vulnerable to simple things like: `<script>alert('test')</script>` or `<img src onerror="document.write('test')">`.