### PR TITLE
 Escape dangerous HTML characters

### DIFF
--- a/src/Encode.coffee
+++ b/src/Encode.coffee
@@ -1,0 +1,5 @@
+class Encode
+  @htmlEntities: (text) ->
+    return text.replace /[&<>'"]/g, (match) -> '&#' + match.charCodeAt(0) + ';'
+
+exports.Encode = Encode

--- a/src/LinkToken.coffee
+++ b/src/LinkToken.coffee
@@ -5,7 +5,7 @@ class LinkToken
   toHTML: ->
     if @manialink and not /^maniaplanet:/i.test(@link)
       @link = "maniaplanet://#manialink=" + @link
-    if not @manialink and not /^http:/i.test(@link)
+    if not @manialink and not /^https?:/i.test(@link)
       @link = "http://" + @link
     return '<a href="' + @link + '">'
 	

--- a/src/LinkToken.coffee
+++ b/src/LinkToken.coffee
@@ -1,3 +1,5 @@
+{Encode} = require './Encode.coffee'
+
 class LinkToken
 
   constructor: (@manialink = false, @link = "") ->
@@ -7,6 +9,8 @@ class LinkToken
       @link = "maniaplanet://#manialink=" + @link
     if not @manialink and not /^https?:/i.test(@link)
       @link = "http://" + @link
+
+    @link = Encode.htmlEntities(@link)
     return '<a href="' + @link + '">'
 	
 exports.LinkToken = LinkToken

--- a/src/Token.coffee
+++ b/src/Token.coffee
@@ -1,11 +1,14 @@
 {Style} = require './Style.coffee'
 {Color} = require './Color.coffee'
+{Encode} = require './Encode.coffee'
 
 class Token
   constructor: (@style = 0, @text = '') ->
 
   toHTML: ->
     styleStack = []
+    @text = Encode.htmlEntities(@text)
+
     if @style
       if @style & Style.COLORED
         # Converting string to hex

--- a/test/parserTest.coffee
+++ b/test/parserTest.coffee
@@ -34,3 +34,13 @@ describe 'Parser', ->
     expect(Parser.toHTML('$l[maniaplanet.com]Maniaplanet', disableLinks: true)).to.equal('Maniaplanet')
   it 'should be darker text with lightBackground', ->
     expect(Parser.toHTML('$fffText', lightBackground: true)).to.equal('<span style="color: #444444;">Text</span>')
+  it 'should encode html tags', ->
+    expect(Parser.toHTML('<script>alert("foo")</script>')).to.equal('&#60;script&#62;alert(&#34;foo&#34;)&#60;/script&#62;')
+  it 'should encode html attributes', ->
+    expect(Parser.toHTML('<img onerror="alert(\'foo\')" />')).to.equal('&#60;img onerror=&#34;alert(&#39;foo&#39;)&#34; /&#62;')
+  it 'should encode html comments', ->
+    expect(Parser.toHTML('<!-- foo -->')).to.equal('&#60;!-- foo --&#62;')
+  it 'should encode html entities', ->
+    expect(Parser.toHTML('foo &amp; bar & baz')).to.equal('foo &#38;amp; bar &#38; baz')
+  it 'should encode html entities in links', ->
+    expect(Parser.toHTML('$l[http://test.com"><script>alert("foo")</script>]foo & bar$l')).to.equal('<a href="http://test.com&#34;&#62;&#60;script&#62;alert(&#34;foo&#34;)&#60;/script&#62;">foo &#38; bar</a>')

--- a/test/parserTest.coffee
+++ b/test/parserTest.coffee
@@ -20,6 +20,8 @@ describe 'Parser', ->
     expect(Parser.toHTML('$l[www.clan-nuitblanche.org]$fff$l')).to.equal('')
   it 'should add http protocol to external links', ->
     expect(Parser.toHTML('$l[maniaplanet.com]maniaplanet$l')).to.equal('<a href="http://maniaplanet.com">maniaplanet</a>')
+  it 'shouldn\'t add http to links already starting with https', ->
+    expect(Parser.toHTML('$l[https://maniaplanet.com]a')).to.equal('<a href="https://maniaplanet.com">a</a>')
   it 'should add maniaplanet protocol to internal links', ->
     expect(Parser.toHTML('$h[maniaflash]ManiaFlash$h')).to.equal('<a href="maniaplanet://#manialink=maniaflash">ManiaFlash</a>')
   it 'should handle color codes', ->


### PR DESCRIPTION
This pull request fixes the lib's vulnerability to xss.

As a proof of concept, the [demo](https://maniaplanet.github.io/maniaplanet-style-js-parser/) is vulnerable to simple things like: `<script>alert('test')</script>` or `<img src onerror="document.write('test')">`.


This PR also fixes the output of links starting with `https:` that were previously prefixed with `http:` anyway (ie. `https://test.com` -> `http://https://test.com`)